### PR TITLE
Логирование запросов к API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require" : {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~5.1 || >= 6.3"
+        "guzzlehttp/guzzle": "~5.1 || >= 6.3",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         verbose="true"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Shiptor API Client">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Core/Configuration.php
+++ b/src/Core/Configuration.php
@@ -1,6 +1,9 @@
 <?php
 namespace ShiptorRussiaApiClient\Client\Core;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
 class Configuration{
     private static $encoding = "UTF-8";
     private static $apiKey = "";
@@ -12,6 +15,7 @@ class Configuration{
     private static $publicUrl;
     private static $baseUrl = 'https://api.shiptor.ru';
     public static $last_query_ts = 0;
+    public static $logger;
 
     const PUBLIC_URL = "/public/v1";
     const PUBLIC_URL_V2 = "/public/v2";
@@ -94,5 +98,18 @@ class Configuration{
     }
     public static function setMaxRequestNum($numOfRequest){
         self::$MAX_REQUEST_PER_SEC = intval($numOfRequest);
+    }
+
+    public static function setLogger(LoggerInterface $logger)
+    {
+        self::$logger = $logger;
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    public static function getLogger()
+    {
+        return self::$logger instanceof LoggerInterface ? self::$logger : new NullLogger();
     }
 }

--- a/tests/Core/ConfigurationTest.php
+++ b/tests/Core/ConfigurationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ShiptorRussiaApiClient\Client\Test\Core;
+
+use Psr\Log\Test\TestLogger;
+use ShiptorRussiaApiClient\Client\Core\Configuration;
+use PHPUnit_Framework_TestCase;
+use ShiptorRussiaApiClient\Client\Shiptor;
+
+class ConfigurationTest extends PHPUnit_Framework_TestCase
+{
+    public function testSetLogger()
+    {
+        $logger = new TestLogger();
+        Configuration::setLogger($logger);
+
+        $this->assertInstanceOf(TestLogger::class, Configuration::getLogger());
+
+        $shiptor = new Shiptor(['API_KEY' => 'UndefinedKeyWithLengthEqualsOrMoreThen40']);
+
+        $logger->reset();
+        $shiptor->ShippingEndpoint()->getStatusList()->send();
+        $this->assertNotEmpty($logger->records[0]);
+        $this->assertStringStartsWith('Request', $logger->records[0]['message']);
+
+        $logger->reset();
+        $shiptor->PublicEndpoint()->getCountries()->send();
+        $this->assertNotEmpty($logger->records[0]);
+        $this->assertStringStartsWith('Request', $logger->records[0]['message']);
+    }
+}


### PR DESCRIPTION
Методом `Configuration::setLogger(LoggerInterface $logger)` можно установить PSR-3 совместимый логгер, который будет использоваться для логирования запросов к API.